### PR TITLE
Accept optional title for template prompt.

### DIFF
--- a/dist/parse-tags.js
+++ b/dist/parse-tags.js
@@ -138,10 +138,11 @@ function () {
   _createClass(TemplateTagParser, [{
     key: "ask",
     value: function ask() {
+      var title = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 'Template Questions';
       var tags = this.tags;
       if (tags.length == 0) return true;
       var prompt = Prompt.create();
-      prompt.title = 'Template Questions';
+      prompt.title = title;
       tags.forEach(function (tag) {
         return prompt.addTextField(tag, tag, '');
       });

--- a/src/template-tag-parser.js
+++ b/src/template-tag-parser.js
@@ -39,12 +39,12 @@ export class TemplateTagParser {
 			.filter(tag => !reservedTags.includes(tag));
 	}
 	
-	ask() {
+	ask(title = 'Template Questions') {
 		let tags = this.tags;
 		if (tags.length == 0) return true;
 		
 		let prompt = Prompt.create();
-		prompt.title = 'Template Questions';
+		prompt.title = title;
 		tags.forEach(tag => prompt.addTextField(tag, tag, ''));
 		prompt.addButton('Okay');
 


### PR DESCRIPTION
Allows for an optional title to be passed into ask(), which is useful when this script is run on a draft that isn’t loaded in the editor, and not visible to the user. A custom title can help give some additional context as to what the parameters in the prompt are for.